### PR TITLE
Add resume mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ status.on('error', err => {
 status.close()
 ```
 
+If you want to resume importing an already existing archive, set `resume: true `. This module then checks a file's size and mtime to determine whether it needs to be updated or created.
+
 ### status
 
 Events:
 
 - `error` (`err`)
-- `file imported` (`path`)
+- `file imported` (`path`, `existed`)
 
 Properties:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you want to resume importing an already existing archive, set `resume: true `
 Events:
 
 - `error` (`err`)
-- `file imported` (`path`, `existed`)
+- `file imported` (`path`, `updated?`)
 
 Properties:
 

--- a/index.js
+++ b/index.js
@@ -60,9 +60,9 @@ module.exports = (archive, files, opts, cb) => {
       })
       pump(rs, ws, done)
     }
-    const done = (err, existed) => {
+    const done = (err, updated) => {
       if (err) return cb(err)
-      status.emit('file imported', file, existed)
+      status.emit('file imported', file, updated)
       cb()
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -141,7 +141,7 @@ test('resume', t => {
     }, err => {
       t.error(err)
     })
-    status.on('file imported', (_, existed) => t.ok(existed))
+    status.on('file imported', (_, updated) => t.ok(updated))
   })
-  status.on('file imported', (_, existed) => t.notOk(existed))
+  status.on('file imported', (_, updated) => t.notOk(updated))
 })

--- a/test/index.js
+++ b/test/index.js
@@ -122,3 +122,26 @@ test('files and directories', t => {
     })
   })
 })
+
+test('resume', t => {
+  t.plan(6)
+
+  const drive = hyperdrive(memdb())
+  const archive = drive.createArchive()
+  let status = hyperImport(archive, [
+    `${__dirname}/fixture/a/b/c/`
+  ], {
+    resume: true
+  }, err => {
+    t.error(err)
+    status = hyperImport(archive, [
+      `${__dirname}/fixture/a/b/c/`
+    ], {
+      resume: true
+    }, err => {
+      t.error(err)
+    })
+    status.on('file imported', (_, existed) => t.ok(existed))
+  })
+  status.on('file imported', (_, existed) => t.notOk(existed))
+})


### PR DESCRIPTION
fixes #2 

When `resume: true`, it only adds files if they don't already exist, and only updates them if mtime and size don't match.

cc @mafintosh @joehand