### PR TITLE
several fixes for resume mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ If you want to resume importing an already existing archive, set `resume: true `
 Events:
 
 - `error` (`err`)
-- `file imported` (`path`, `updated?`)
+- `file imported` ({ `path`, `mode=updated|created` })
+- `file skipped` ({ `path` })
 
 Properties:
 


### PR DESCRIPTION
- distinguish update vs create event
- add "file skipped" event
- fix stats counting

there was also a bug where the internal hyperdrive entries cache wasn't updated after a modification.

this is a breaking change

cc @joehand