### PR TITLE
change api from files.. to directory, to simplify path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # hyperdrive-import-files
 
-Import some files and folders into a [hyperdrive](https://github.com/mafintosh/hyperdrive), and optionally keep watching for changes.
+Import the contents of a folder into a [hyperdrive](https://github.com/mafintosh/hyperdrive), and optionally keep watching for changes.
 
 [![Build Status](https://travis-ci.org/juliangruber/hyperdrive-import-files.svg?branch=master)](https://travis-ci.org/juliangruber/hyperdrive-import-files)
 
@@ -15,10 +15,7 @@ const hyperImport = require('hyperdrive-import-files')
 const drive = hyperdrive(memdb())
 const archive = drive.createArchive()
 
-hyperImport(archive, [
-  'a/directory/',
-  'some/file.txt'
-], err => {
+hyperImport(archive, 'a/directory/', err => {
   // ...
 })
 ```
@@ -31,9 +28,9 @@ $ npm install hyperdrive-import-files
 
 ## API
 
-### hyperImport(archive, files, [, options][, cb])
+### hyperImport(archive, directory, [, options][, cb])
 
-Recursively import `files` into `archive` and call `cb` with the potential error. The import happens sequentually. Returns a `status` object.
+Recursively import `directory` into `archive` and call `cb` with the potential error. The import happens sequentually. Returns a `status` object.
 
 Options
 
@@ -44,7 +41,7 @@ Options
 To enable watching, set `live: true`, like this:
 
 ```js
-const status = hyperImport(archive, files, { live: true }, err => {
+const status = hyperImport(archive, directory, { live: true }, err => {
   console.log('initial import done')  
 })
 status.on('error', err => {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const pump = require('pump')
 const fs = require('fs')
 const join = require('path').join
 const relative = require('path').relative
-const common = require('common-path-prefix')
 const EventEmitter = require('events').EventEmitter
 const chokidar = require('chokidar')
 const series = require('run-series')
@@ -12,25 +11,21 @@ const match = require('anymatch')
 
 const noop = () => {}
 
-module.exports = (archive, files, opts, cb) => {
+module.exports = (archive, dir, opts, cb) => {
   if (typeof opts === 'function') {
     cb = opts
     opts = {}
   }
   opts = opts || {}
 
-  if (!files || !files.length) return setImmediate(cb || noop)
-  files = Array.from(files)
-
   const emitError = (err) => err && status.emit('error', err)
   cb = cb || emitError
 
-  const prefix = common(files)
   const entries = {}
   let watcher
 
   if (opts.live) {
-    watcher = chokidar.watch([files], {
+    watcher = chokidar.watch([dir], {
       persistent: true,
       ignored: opts.ignore
     })
@@ -60,7 +55,7 @@ module.exports = (archive, files, opts, cb) => {
 
   const consumeFile = (file, stat, cb) => {
     cb = cb || emitError
-    const hyperPath = relative(prefix, file)
+    const hyperPath = relative(dir, file)
     const next = () => {
       const rs = fs.createReadStream(file)
       const ws = archive.createFileWriteStream({
@@ -100,11 +95,8 @@ module.exports = (archive, files, opts, cb) => {
     })
   }
 
-  const next = err => {
-    if (err) return cb(err)
-    const file = files.shift()
-    if (!file) return cb()
-    consume(file, next)
+  const next = () => {
+    consumeDir(dir, cb || emitError)
   }
 
   if (opts.resume) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "chokidar": "^1.6.0",
-    "common-path-prefix": "^1.0.0",
     "pump": "^1.0.1",
     "run-series": "^1.1.4"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -8,66 +8,17 @@ const fs = require('fs')
 
 const sort = entries => entries.sort((a, b) => a.name.localeCompare(b.name))
 
-test('no files', t => {
-  t.plan(6)
-
-  const drive = hyperdrive(memdb())
-  const archive = drive.createArchive()
-  hyperImport(archive, null, err => {
-    t.error(err)
-
-    archive.list((err, entries) => {
-      t.error(err)
-      t.equal(entries.length, 0)
-
-      hyperImport(archive, [], err => {
-        t.error(err)
-
-        archive.list((err, entries) => {
-          t.error(err)
-          t.equal(entries.length, 0)
-        })
-      })
-    })
-  })
-})
-
-test('single file', t => {
+test('import', t => {
   t.plan(7)
 
   const drive = hyperdrive(memdb())
   const archive = drive.createArchive()
-  const status = hyperImport(archive, [
-    `${__dirname}/fixture/a/b/c/d.txt`
-  ], err => {
+  const status = hyperImport(archive, `${__dirname}/fixture/a/b/c/`, err => {
     t.error(err)
 
     archive.list((err, entries) => {
       t.error(err)
-      t.equal(entries.length, 1)
-      t.equal(entries[0].name, 'd.txt')
-      t.equal(status.fileCount, 1)
-      t.equal(status.totalSize, 4)
-    })
-  })
-  status.on('file imported', file => {
-    t.equal(file, `${__dirname}/fixture/a/b/c/d.txt`)
-  })
-})
-
-test('multiple files', t => {
-  t.plan(7)
-
-  const drive = hyperdrive(memdb())
-  const archive = drive.createArchive()
-  const status = hyperImport(archive, [
-    `${__dirname}/fixture/a/b/c/d.txt`,
-    `${__dirname}/fixture/a/b/c/e.txt`
-  ], err => {
-    t.error(err)
-
-    archive.list((err, entries) => {
-      t.error(err)
+      entries = sort(entries)
       t.equal(entries.length, 2)
       t.equal(entries[0].name, 'd.txt')
       t.equal(entries[1].name, 'e.txt')
@@ -77,66 +28,16 @@ test('multiple files', t => {
   })
 })
 
-test('directory', t => {
-  t.plan(7)
-
-  const drive = hyperdrive(memdb())
-  const archive = drive.createArchive()
-  const status = hyperImport(archive, [
-    `${__dirname}/fixture/a/b`
-  ], err => {
-    t.error(err)
-
-    archive.list((err, entries) => {
-      t.error(err)
-      entries = sort(entries)
-      t.equal(entries.length, 2)
-      t.equal(entries[0].name, 'b/c/d.txt')
-      t.equal(entries[1].name, 'b/c/e.txt')
-      t.equal(status.fileCount, 2)
-      t.equal(status.totalSize, 9)
-    })
-  })
-})
-
-test('files and directories', t => {
-  t.plan(8)
-
-  const drive = hyperdrive(memdb())
-  const archive = drive.createArchive()
-  const status = hyperImport(archive, [
-    `${__dirname}/fixture/a/b/c/`,
-    `${__dirname}/index.js`
-  ], err => {
-    t.error(err)
-
-    archive.list((err, entries) => {
-      t.error(err)
-      entries = sort(entries)
-      t.equal(entries.length, 3)
-      t.equal(entries[0].name, 'fixture/a/b/c/d.txt')
-      t.equal(entries[1].name, 'fixture/a/b/c/e.txt')
-      t.equal(entries[2].name, 'index.js')
-      t.equal(status.fileCount, 3)
-      t.equal(status.totalSize, 9 + fs.statSync(`${__dirname}/index.js`).size)
-    })
-  })
-})
-
 test('resume', t => {
   t.plan(6)
 
   const drive = hyperdrive(memdb())
   const archive = drive.createArchive()
-  let status = hyperImport(archive, [
-    `${__dirname}/fixture/a/b/c/`
-  ], {
+  let status = hyperImport(archive, `${__dirname}/fixture/a/b/c/`, {
     resume: true
   }, err => {
     t.error(err)
-    status = hyperImport(archive, [
-      `${__dirname}/fixture/a/b/c/`
-    ], {
+    status = hyperImport(archive, `${__dirname}/fixture/a/b/c/`, {
       resume: true
     }, err => {
       t.error(err)
@@ -151,29 +52,25 @@ test('optional callback', t => {
 
   const drive = hyperdrive(memdb())
   const archive = drive.createArchive()
-  let status = hyperImport(archive, [
-    `${__dirname}/fixture/a/b/c/d.txt`
-  ])
-  status.on('file imported', () => t.ok(true))
+  let status = hyperImport(archive, `${__dirname}/fixture/a/b/c/`)
+  status.once('file imported', () => t.ok(true))
 })
 
 test('ignore', t => {
   const drive = hyperdrive(memdb())
   const archive = drive.createArchive()
-  const status = hyperImport(archive, [
-    `${__dirname}/fixture/ignore`
-  ], {
+  const status = hyperImport(archive, `${__dirname}/fixture/ignore`, {
     ignore: /\/\.dat\//,
     live: true
   }, err => {
-    t.error(err)
+    t.error(err, 'no error importing')
     fs.writeFile(`${__dirname}/fixture/ignore/.dat/beep.txt`, 'boop', err => {
-      t.error(err)
+      t.error(err, 'no error writing file')
       t.end()
       status.close()
     })
   })
-  status.on('file imported', () => t.fail())
+  status.on('file imported', () => t.ok(false))
 })
 
 test('chokidar bug', t => {
@@ -181,3 +78,4 @@ test('chokidar bug', t => {
   t.end()
   process.exit()
 })
+


### PR DESCRIPTION
fixes #9

This changes the api from taking a files array to just one directory. That simplifies path and prefix calculation by a lot.

When you import `foo/bar`, the file `foo/bar/baz.txt` will end up at `/baz.txt`. When you import `foo`, then file `foo/bar/baz.txt` will end up at `bar/baz.txt`. So it's a lot more reliable and the output is easier determinable.

I initially had `files` be an array of file or folder paths in order to give biggest possible freedom to a file picker dialog wanting to import files, however this ended up complicating this module too much.

This is a breaking change.

cc @joehand