### PR TITLE
Prevent live mode from continuous looping on created.

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = (archive, dir, opts, cb) => {
     }
 
     let entry = entries[hyperPath]
-    if (!opts.resume || !entry) {
+    if (!entry) {
       status.fileCount++
       status.totalSize += stat.size
       next('created')


### PR DESCRIPTION
If `opts = {live: true, resume: false}` then this if statement will always be true. We don't need to check for `!opts.resume` since if there is an entry we know [it was resumed](https://github.com/juliangruber/hyperdrive-import-files/blob/master/index.js#L104).

This will allow live files changes to reach the updated option.

