### PR TITLE
Use directory for stats instead of hyperdrive/directory hybrid

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,8 @@ module.exports = (archive, dir, opts, cb) => {
         entry = entries[hyperPath] = entry || {}
         entry.length = stat.size
         entry.mtime = stat.mtime.getTime()
+        status.fileCount++
+        status.totalSize += stat.size
         status.emit('file imported', {
           path: file,
           mode
@@ -75,13 +77,12 @@ module.exports = (archive, dir, opts, cb) => {
 
     let entry = entries[hyperPath]
     if (!entry) {
-      status.fileCount++
-      status.totalSize += stat.size
       next('created')
     } else if (entry.length !== stat.size || entry.mtime !== stat.mtime.getTime()) {
-      status.totalSize = status.totalSize - entry.length + stat.size
       next('updated')
     } else {
+      status.fileCount++
+      status.totalSize += entry.length
       status.emit('file skipped', { path: file })
       cb()
     }
@@ -106,8 +107,6 @@ module.exports = (archive, dir, opts, cb) => {
     .on('error', cb)
     .on('data', entry => {
       entries[entry.name] = entry
-      status.fileCount++
-      status.totalSize += entry.length
     })
     .on('end', next)
   } else {

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,7 @@ test('import', t => {
 })
 
 test('resume', t => {
-  t.plan(12)
+  t.plan(13)
 
   const drive = hyperdrive(memdb())
   const archive = drive.createArchive()
@@ -42,11 +42,12 @@ test('resume', t => {
         resume: true
       }, err => {
         t.error(err)
+        t.equal(status.fileCount, 2)
+        t.equal(status.totalSize, 9)
       })
       status.on('file imported', file => {
         t.equal(file.mode, 'updated', 'updated')
-        t.equal(status.fileCount, 3)
-        t.equal(status.totalSize, 13)
+        t.equal(file.path, `${__dirname}/fixture/a/b/c/d.txt`)
       })
       status.on('file skipped', file => {
         t.equal(file.path, `${__dirname}/fixture/a/b/c/e.txt`)


### PR DESCRIPTION
This changes the stats to use the imported directory as the "truth" for the stats instead of the hyperdrive instance. It seems like for this use case, we should show stats for the directory, not the hyperdrive. But I could see why that may be confusing too...

Previously it was a mix of stats from the hyperdrive and directory. I was running into some bugs with the progress stats and ended up here.

In this PR, the stats are updated *after* files are added to the hyperdrive. This allows stats to be used for actual progress. Before that didn't work because you didn't know what would happen with files existing in archive. 