### PR TITLE
Temporary fix to create empty dirs

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,13 +94,11 @@ module.exports = (archive, target, opts, cb) => {
 
   const consumeDir = (file, stat, cb) => {
     cb = cb || emitError
-    archive.createFileWriteStream({
+    archive.append({
       name: relative(target, file),
       type: 'directory',
       mtime: stat.mtime
-    })
-    .on('error', cb)
-    .on('finish', () => {
+    }, () => {
       fs.readdir(file, (err, _files) => {
         if (err) return cb(err)
         series(_files.map(_file => done => {
@@ -108,7 +106,6 @@ module.exports = (archive, target, opts, cb) => {
         }), cb)
       })
     })
-    .end()
   }
 
   const next = () => {


### PR DESCRIPTION
The empty dir fix in 2.2.0 wasn't working always (I think because of [this issue](https://github.com/mafintosh/hyperdrive/issues/83)). `archive.append` writes the entry manually if its not a file instead so it at least gets in the metadata.