### PR TITLE
start live watching after import finished

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,18 +25,6 @@ module.exports = (archive, target, opts, cb) => {
   const entries = {}
   let watcher
 
-  if (opts.live) {
-    watcher = chokidar.watch([target], {
-      persistent: true,
-      ignored: opts.ignore
-    })
-    watcher.once('ready', () => {
-      watcher.on('add', path => consume(path))
-      watcher.on('change', path => consume(path))
-      watcher.on('unlink', path => noop) // TODO
-    })
-  }
-
   const status = new EventEmitter()
   status.close = () => watcher && watcher.close()
   status.fileCount = 0
@@ -109,7 +97,21 @@ module.exports = (archive, target, opts, cb) => {
   }
 
   const next = () => {
-    consume(target, cb || emitError)
+    consume(target, (err) => {
+      if (err) return cb(err)
+      if (opts.live) {
+        watcher = chokidar.watch([target], {
+          persistent: true,
+          ignored: opts.ignore
+        })
+        watcher.once('ready', () => {
+          watcher.on('add', path => consume(path))
+          watcher.on('change', path => consume(path))
+          watcher.on('unlink', path => noop) // TODO
+        })
+      }
+      cb()
+    })
   }
 
   if (opts.resume) {


### PR DESCRIPTION
This PR waits to watch files until the import is finished. 

Unfortunately, we may miss file changes with this (if a file is imported, changed before the watcher starts, and finally import finishes). But I think right now the change events are pretty aggressive and this is causing some unwanted bugs. 