### PR TITLE
add basePath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Options
 
 - `live`: keep watching
 - `resume`: assume the archive isn't fresh
+- `basePath`: where in the archive should the files import to? (defaults to '')
 - `ignore`: [anymatch](https://npmjs.org/package/anymatch) expression to ignore files
 
 To enable watching, set `live: true`, like this:
@@ -52,6 +53,12 @@ status.close()
 ```
 
 If you want to resume importing an already existing archive, set `resume: true `. This module then checks a file's size and mtime to determine whether it needs to be updated or created.
+
+If you want to import into a subfolder, set `basePath`:
+
+```js
+hyperImport(archive, target, { basePath: '/some/subdir' }, err => {...})
+```
 
 ### status
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = (archive, target, opts, cb) => {
   const emitError = (err) => err && status.emit('error', err)
   cb = cb || emitError
 
+  const basePath = (typeof opts.basePath === 'string') ? opts.basePath : ''
   const entries = {}
   let watcher
 
@@ -57,8 +58,8 @@ module.exports = (archive, target, opts, cb) => {
   const consumeFile = (file, stat, cb) => {
     cb = cb || emitError
     const hyperPath = file === target
-      ? basename(file)
-      : relative(target, file)
+      ? joinHyperPath(basePath, basename(file))
+      : joinHyperPath(basePath, relative(target, file))
     const next = mode => {
       const rs = fs.createReadStream(file)
       const ws = archive.createFileWriteStream({
@@ -94,7 +95,7 @@ module.exports = (archive, target, opts, cb) => {
 
   const consumeDir = (file, stat, cb) => {
     cb = cb || emitError
-    const hyperPath = relative(target, file)
+    const hyperPath = joinHyperPath(basePath, relative(target, file))
     let entry = entries[hyperPath]
 
     const next = () => {
@@ -141,3 +142,11 @@ module.exports = (archive, target, opts, cb) => {
   return status
 }
 
+function joinHyperPath (base, path) {
+  path = join(base, path)
+  // don't allow '.'
+  if (path === '.') {
+    return ''
+  }
+  return path
+}

--- a/index.js
+++ b/index.js
@@ -144,8 +144,9 @@ module.exports = (archive, target, opts, cb) => {
 
 function joinHyperPath (base, path) {
   path = join(base, path)
-  // don't allow '.'
   if (path === '.') {
+    // '.' is returned when base is '' and path is '': aka, the root directory
+    // in hyperdrive, root should be '' or '/', so we replace it with this special case
     return ''
   }
   return path

--- a/test/index.js
+++ b/test/index.js
@@ -226,9 +226,49 @@ test('duplicate directory', t => {
   })
 })
 
+test('import directory with basePath', t => {
+  t.plan(8)
+
+  const drive = hyperdrive(memdb())
+  const archive = drive.createArchive()
+  const status = hyperImport(archive, `${__dirname}/fixture/a/b/c/`, { basePath: 'foo/bar' }, err => {
+    t.error(err)
+
+    archive.list((err, entries) => {
+      t.error(err)
+      entries = sort(entries)
+      t.equal(entries.length, 3)
+      t.equal(entries[0].name, 'foo/bar')
+      t.equal(entries[1].name, 'foo/bar/d.txt')
+      t.equal(entries[2].name, 'foo/bar/e.txt')
+      t.equal(status.fileCount, 2)
+      t.equal(status.totalSize, 9)
+    })
+  })
+})
+
+test('import file with basePath', t => {
+  t.plan(6)
+
+  const drive = hyperdrive(memdb())
+  const archive = drive.createArchive()
+  const status = hyperImport(archive, `${__dirname}/fixture/a/b/c/d.txt`, { basePath: 'foo/bar' }, err => {
+    t.error(err)
+
+    archive.list((err, entries) => {
+      t.error(err)
+      entries = sort(entries)
+      t.equal(entries.length, 1)
+      t.equal(entries[0].name, 'foo/bar/d.txt')
+      t.equal(status.fileCount, 1)
+      t.equal(status.totalSize, 4)
+    })
+  })
+})
+
+// NOTE: this test must be last
 test('chokidar bug', t => {
   // chokidar sometimes keeps the process open
   t.end()
   process.exit()
 })
-


### PR DESCRIPTION
Adding this for some features in beaker.

Allows you to import into a subfolder of the archive by specifying the `basePath` option.