### PR TITLE
set entries before write finishes

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,11 +66,11 @@ module.exports = (archive, target, opts, cb) => {
         name: hyperPath,
         mtime: stat.mtime
       })
+      entry = entries[hyperPath] = entry || {}
+      entry.length = stat.size
+      entry.mtime = stat.mtime.getTime()
       pump(rs, ws, err => {
         if (err) return cb(err)
-        entry = entries[hyperPath] = entry || {}
-        entry.length = stat.size
-        entry.mtime = stat.mtime.getTime()
         status.emit('file imported', {
           path: file,
           mode


### PR DESCRIPTION
This fixes duplicate entries that have a watch event fired before the write finishes.
