### PR TITLE
Fix consume function call for live watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,12 @@ module.exports = function (archive, target, opts, cb) {
       ignored: opts.ignore
     })
     watcher.once('ready', function () {
-      watcher.on('add', consume)
-      watcher.on('change', consume)
+      watcher.on('add', function (file, stat) {
+        consume(file, noop)
+      })
+      watcher.on('change', function (file, stat) {
+        consume(file, noop)
+      })
       watcher.on('unlink', noop) // TODO
     })
   }

--- a/index.js
+++ b/index.js
@@ -36,10 +36,10 @@ module.exports = function (archive, target, opts, cb) {
     })
     watcher.once('ready', function () {
       watcher.on('add', function (file, stat) {
-        consume(file, noop)
+        consume(file)
       })
       watcher.on('change', function (file, stat) {
-        consume(file, noop)
+        consume(file)
       })
       watcher.on('unlink', noop) // TODO
     })


### PR DESCRIPTION
The watch callback was calling consume with the wrong arguments. This was failing locally for me with the test travis skips.

We could also use the stats object in consume, since the watcher already has it, rather than doing fs.stats again. Let me know if you want me to add that.