### PR TITLE
Do not store or check mtime for directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,13 +125,12 @@ module.exports = function (archive, target, opts, cb) {
       })
     }
 
-    if (entry && entry.mtime === stat.mtime.getTime()) {
+    if (entry) {
       next()
     } else {
       archive.append({
         name: hyperPath,
-        type: 'directory',
-        mtime: stat.mtime
+        type: 'directory'
       }, next)
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -264,7 +264,6 @@ test('duplicate subdirectory', function (t) {
           t.error(err)
 
           entries = sort(entries)
-          console.log(entries)
           t.equal(entries.length, 4)
           t.equal(entries[0].name, '')
           t.equal(entries[1].name, 'c')

--- a/test/index.js
+++ b/test/index.js
@@ -234,6 +234,35 @@ test('duplicate directory', function (t) {
   })
 })
 
+test('duplicate subdirectory', function (t) {
+  var drive = hyperdrive(memdb())
+  var archive = drive.createArchive()
+  var directory = path.join(__dirname, '/fixture/a/b/')
+
+  hyperImport(archive, directory, function (err) {
+    t.error(err)
+    fs.utimes(path.join(directory, 'c'), NaN, NaN, function () {
+      hyperImport(archive, directory, {
+        resume: true
+      }, function (err) {
+        t.error(err)
+        archive.list(function (err, entries) {
+          t.error(err)
+
+          entries = sort(entries)
+          console.log(entries)
+          t.equal(entries.length, 4)
+          t.equal(entries[0].name, '')
+          t.equal(entries[1].name, 'c')
+          t.equal(entries[2].name, 'c/d.txt')
+          t.equal(entries[3].name, 'c/e.txt')
+          t.end()
+        })
+      })
+    })
+  })
+})
+
 test('import directory with basePath', function (t) {
   t.plan(8)
 


### PR DESCRIPTION
We were getting a lot of duplicate directory entries because of updated mtimes. 

This PR just adds directories once, not storing or checking mtimes.