### PR TITLE
Update live watching option and add live change event

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Events:
 - `error` (`err`)
 - `file imported` ({ `path`, `mode=updated|created` })
 - `file skipped` ({ `path` })
-- `file watched` ({ `path`, `mode=updated|created` })
+- `file watch event` ({ `path`, `mode=updated|created` })
 
 Properties:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Recursively import `target`, which is the path to a directory or file,  into `ar
 
 Options
 
-- `live`: keep watching
+- `watch`: watch files for changes & import on change (archive must be live)
 - `overwrite`: allow files in the archive to be overwritten (defaults to true)
 - `resume`: assume the archive isn't fresh
 - `basePath`: where in the archive should the files import to? (defaults to '')
@@ -42,10 +42,10 @@ Options
 - `dryRun`: step through the import, but don't write any files to the archive (defaults to false)
 - `indexing`: Useful if `target === dest` so hyperdrive does not rewrite the files on import.
 
-To enable watching, set `live: true`, like this:
+To enable watching, set `watch: true`, like this:
 
 ```js
-const status = hyperImport(archive, target, { live: true }, err => {
+const status = hyperImport(archive, target, { watch: true }, err => {
   console.log('initial import done')
 })
 status.on('error', err => {
@@ -70,6 +70,7 @@ Events:
 - `error` (`err`)
 - `file imported` ({ `path`, `mode=updated|created` })
 - `file skipped` ({ `path` })
+- `file watched` ({ `path`, `mode=updated|created` })
 
 Properties:
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (archive, target, opts, cb) {
     opts = {}
   }
   opts = opts || {}
-  opts.watch = opts.watch || opts.live
+  var watch = opts.watch || opts.live
 
   var overwrite = opts.overwrite !== false
   var dryRun = opts.dryRun === true
@@ -32,7 +32,7 @@ module.exports = function (archive, target, opts, cb) {
   var entries = {}
   var watcher
 
-  if (opts.watch && archive.live) {
+  if (watch && archive.live) {
     watcher = chokidar.watch([target], {
       persistent: true,
       ignored: opts.ignore
@@ -126,7 +126,7 @@ module.exports = function (archive, target, opts, cb) {
         next('created')
       } else if (entry.length !== stat.size || entry.mtime !== stat.mtime.getTime()) {
         status.totalSize = status.totalSize - entry.length + stat.size
-        if (opts.watch) status.bytesImported -= entry.length
+        if (watch) status.bytesImported -= entry.length
         next('updated')
       } else {
         status.bytesImported += stat.size

--- a/index.js
+++ b/index.js
@@ -39,11 +39,11 @@ module.exports = function (archive, target, opts, cb) {
     })
     watcher.once('ready', function () {
       watcher.on('add', function (file, stat) {
-        status.emit('file watched', {path: file, mode: 'add'})
+        status.emit('file watched', {path: file, mode: 'created'})
         consume(file, stat)
       })
       watcher.on('change', function (file, stat) {
-        status.emit('file watched', {path: file, mode: 'change'})
+        status.emit('file watched', {path: file, mode: 'updated'})
         consume(file, stat)
       })
       watcher.on('unlink', noop) // TODO

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = function (archive, target, opts, cb) {
     opts = {}
   }
   opts = opts || {}
+  opts.watch = opts.watch || opts.live
 
   var overwrite = opts.overwrite !== false
   var dryRun = opts.dryRun === true
@@ -31,7 +32,7 @@ module.exports = function (archive, target, opts, cb) {
   var entries = {}
   var watcher
 
-  if (opts.live) {
+  if (opts.watch && archive.live) {
     watcher = chokidar.watch([target], {
       persistent: true,
       ignored: opts.ignore
@@ -123,7 +124,7 @@ module.exports = function (archive, target, opts, cb) {
         next('created')
       } else if (entry.length !== stat.size || entry.mtime !== stat.mtime.getTime()) {
         status.totalSize = status.totalSize - entry.length + stat.size
-        if (opts.live) status.bytesImported -= entry.length
+        if (opts.watch) status.bytesImported -= entry.length
         next('updated')
       } else {
         status.bytesImported += stat.size

--- a/index.js
+++ b/index.js
@@ -39,9 +39,11 @@ module.exports = function (archive, target, opts, cb) {
     })
     watcher.once('ready', function () {
       watcher.on('add', function (file, stat) {
+        status.emit('file watched', {path: file, mode: 'add'})
         consume(file, stat)
       })
       watcher.on('change', function (file, stat) {
+        status.emit('file watched', {path: file, mode: 'change'})
         consume(file, stat)
       })
       watcher.on('unlink', noop) // TODO

--- a/index.js
+++ b/index.js
@@ -39,11 +39,11 @@ module.exports = function (archive, target, opts, cb) {
     })
     watcher.once('ready', function () {
       watcher.on('add', function (file, stat) {
-        status.emit('file watched', {path: file, mode: 'created'})
+        status.emit('file watch event', {path: file, mode: 'created'})
         consume(file, stat)
       })
       watcher.on('change', function (file, stat) {
-        status.emit('file watched', {path: file, mode: 'updated'})
+        status.emit('file watch event', {path: file, mode: 'updated'})
         consume(file, stat)
       })
       watcher.on('unlink', noop) // TODO

--- a/test/index.js
+++ b/test/index.js
@@ -160,7 +160,7 @@ test('resume with raf', function (t) {
 
 if (!process.env.TRAVIS) {
   test('resume & live', function (t) {
-    t.plan(12)
+    t.plan(13)
 
     var drive = hyperdrive(memdb())
     var archive = drive.createArchive()
@@ -176,6 +176,10 @@ if (!process.env.TRAVIS) {
         t.equal(status.fileCount, 3, 'file count')
         t.equal(status.totalSize, 11, 'total size')
         t.equal(status.bytesImported, 11, 'bytes imported')
+
+        status.once('file watched', function (file) {
+          t.equal(file.mode, 'updated', 'updated')
+        })
 
         status.once('file imported', function (file) {
           t.equal(file.mode, 'updated', 'updated')

--- a/test/index.js
+++ b/test/index.js
@@ -177,7 +177,7 @@ if (!process.env.TRAVIS) {
         t.equal(status.totalSize, 11, 'total size')
         t.equal(status.bytesImported, 11, 'bytes imported')
 
-        status.once('file watched', function (file) {
+        status.once('file watch event', function (file) {
           t.equal(file.mode, 'updated', 'updated')
         })
 


### PR DESCRIPTION
* Changes `opts.live` to `opts.watch` (issue #39) with backwards compatibility
* Adds 1 event, `importer.on('file watched', {path: '/file-path', mode:'created|updated'})`