### PR TITLE
fix archive write stream option

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,9 +86,8 @@ module.exports = function (archive, target, opts, cb) {
       var rs = fs.createReadStream(file)
       var ws = archive.createFileWriteStream({
         name: hyperPath,
-        mtime: stat.mtime,
-        indexing: opts.indexing
-      })
+        mtime: stat.mtime
+      }, {indexing: opts.indexing})
       entry = entries[hyperPath] = entry || {}
       entry.length = stat.size
       entry.mtime = stat.mtime.getTime()


### PR DESCRIPTION
I had this option wrong before, the first argument is entry and second options: `archive.createFileWriteStream(entry, opts)`. 