### PR TITLE
Add opts.compareFileContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Options
 
 - `watch`: watch files for changes & import on change (archive must be live)
 - `overwrite`: allow files in the archive to be overwritten (defaults to true)
+- `compareFileContent`: compare import-candidates to archive's internal copy. If false, will only compare mtime and file-size, which is faster but may reslt in false-positives. (defaults to false)
 - `resume`: assume the archive isn't fresh
 - `basePath`: where in the archive should the files import to? (defaults to '')
 - `ignore`: [anymatch](https://npmjs.org/package/anymatch) expression to ignore files

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = function (archive, target, opts, cb) {
 
   var overwrite = opts.overwrite !== false
   var dryRun = opts.dryRun === true
+  var compareFileContent = opts.compareFileContent === true
   function emitError (err) {
     if (err) status.emit('error', err)
   }
@@ -125,14 +126,22 @@ module.exports = function (archive, target, opts, cb) {
         status.totalSize += stat.size
         next('created')
       } else if (entry.length !== stat.size || entry.mtime !== stat.mtime.getTime()) {
-        isDuplicate(archive, file, hyperPath, function (err, duplicate) {
-          if (!err && duplicate) return skip()
-          status.totalSize = status.totalSize - entry.length + stat.size
-          if (watch) status.bytesImported -= entry.length
-          next('updated')
-        })
+        if (compareFileContent) {
+          isDuplicate(archive, file, hyperPath, function (err, duplicate) {
+            if (!err && duplicate) return skip()
+            addChanged()
+          })
+        } else {
+          addChanged()
+        }
       } else {
         skip()
+      }
+
+      function addChanged () {
+        status.totalSize = status.totalSize - entry.length + stat.size
+        if (watch) status.bytesImported -= entry.length
+        next('updated')
       }
 
       function skip () {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "chokidar": "^1.6.0",
+    "hyperdrive-duplicate": "^1.0.0",
     "pump": "^1.0.1",
     "run-series": "^1.1.4",
     "through2": "^2.0.3"


### PR DESCRIPTION
Builds on https://github.com/juliangruber/hyperdrive-import-files/pull/31

Adds the `compareFileContent` option which, if true, will check the file content before importing.

Why: I have a command, `bkr status`, that's like `git status`. Since HIF currently goes by mtime and size, if you copy a directory and then run `bkr status` in the new dir, everything gets incorrectly reported as changed. This solves the issue.