### PR TITLE
Normalize archive entry paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ module.exports = function (archive, target, opts, cb) {
     archive.list({ live: false })
     .on('error', cb)
     .on('data', function (entry) {
-      entries[entry.name] = entry
+      entries[normalizeEntryPath(entry.name)] = entry
       if (entry.type === 'directory') return
       status.fileCount++
       status.totalSize += entry.length
@@ -200,6 +200,13 @@ module.exports = function (archive, target, opts, cb) {
   }
 
   return status
+}
+
+function normalizeEntryPath (path) {
+  if (typeof path === 'string' && !path.startsWith('/')) {
+    return '/' + path
+  }
+  return path
 }
 
 function joinHyperPath (base, path) {

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports = function (archive, target, opts, cb) {
         next('created')
       } else if (entry.length !== stat.size || entry.mtime !== stat.mtime.getTime()) {
         if (compareFileContent) {
-          isDuplicate(archive, file, hyperPath, function (err, duplicate) {
+          isDuplicate(archive, file, entry.name, function (err, duplicate) {
             if (!err && duplicate) return skip()
             addChanged()
           })

--- a/index.js
+++ b/index.js
@@ -216,5 +216,5 @@ function joinHyperPath (base, path) {
     // in hyperdrive, root should be '' or '/', so we replace it with this special case
     return ''
   }
-  return path
+  return normalizeEntryPath(path)
 }

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports = function (archive, target, opts, cb) {
         next('created')
       } else if (entry.length !== stat.size || entry.mtime !== stat.mtime.getTime()) {
         if (compareFileContent) {
-          isDuplicate(archive, file, entry.name, function (err, duplicate) {
+          isDuplicate(archive, file, hyperPath, function (err, duplicate) {
             if (!err && duplicate) return skip()
             addChanged()
           })
@@ -203,8 +203,8 @@ module.exports = function (archive, target, opts, cb) {
 }
 
 function normalizeEntryPath (path) {
-  if (typeof path === 'string' && !path.startsWith('/')) {
-    return '/' + path
+  if (typeof path === 'string' && path.charAt(0) === '/') {
+    return path.slice(1)
   }
   return path
 }


### PR DESCRIPTION
There's inconsistent standards, among modules, as to whether there should be a leading / in hyperdrive entries. It manifests as files being added twice: if you have a `foo.txt`, import-files will treat `/foo.txt` as a different file and readd it.

This PR protects against that inconsistency by normalizing the entries on read, thereby causeing import-files to recognize foo.txt == /foo.txt

