### PR TITLE
WIP: support for hyperdrive v8

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,10 +89,7 @@ module.exports = function (archive, target, opts, cb) {
         return pumpDone()
       }
       var rs = fs.createReadStream(file)
-      var ws = archive.createFileWriteStream({
-        name: hyperPath,
-        mtime: stat.mtime
-      }, {indexing: opts.indexing})
+      var ws = archive.createWriteStream(hyperPath, {indexing: opts.indexing})
       entry = entries[hyperPath] = entry || {}
       entry.length = stat.size
       entry.mtime = stat.mtime.getTime()
@@ -174,10 +171,12 @@ module.exports = function (archive, target, opts, cb) {
     if (dryRun || entry) {
       next()
     } else {
-      archive.append({
-        name: hyperPath,
-        type: 'directory'
-      }, next)
+      next()
+      // TODO: not doing this in v8?
+      // archive.append({
+      //   name: hyperPath,
+      //   type: 'directory'
+      // }, next)
     }
   }
 
@@ -186,7 +185,7 @@ module.exports = function (archive, target, opts, cb) {
   }
 
   if (opts.resume) {
-    archive.list({ live: false })
+    archive.history({ live: false })
     .on('error', cb)
     .on('data', function (entry) {
       entries[normalizeEntryPath(entry.name)] = entry

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "chokidar": "^1.6.0",
+    "hyperdrive": "github:mafintosh/hyperdrive#v8",
     "hyperdrive-duplicate": "^1.0.0",
     "pump": "^1.0.1",
     "run-series": "^1.1.4",


### PR DESCRIPTION
Updated with basic API changes so we can start using as is. Some further optimizations we can do with v8 support in TODO.

### TODO: 
- [ ] change `opts.resume` behavior to use `archive.stat` or `archive.access`. I think we can do this per-entry now instead of going through the history before starting.
- [ ] use [archive.stat()](https://github.com/mafintosh/hyperdrive/tree/v8#drivestatname-callback) to compare mtimes (will this be supported?)
- [ ] Figure out how directories are handled
- [ ] `createWriteStream` [indexing option](https://github.com/juliangruber/hyperdrive-import-files/compare/master...hyperdrive-v8#diff-168726dbe96b3ce427e7fedce31bb0bcR92) support?
- [ ] upgrade hyperdrive-duplicate to v2 ([SLEEP PR](https://github.com/joehand/hyperdrive-duplicate/pull/1) is ready there, waiting for official hyperdrive v8 release).
- [ ] update tests